### PR TITLE
Update `lsp4ij` to v0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Update `lsp4ij` version to v0.19.2
+- Update `lsp4ij` version to v0.19.3
 - Bump `gradle-wrapper` from 9.3.1 to 9.4.1
 - Bump `org.jetbrains.kotlin.jvm` from 2.3.0 to 2.3.20
 - Bump `org.jetbrains.kotlinx.kover` from 0.9.4 to 0.9.8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ changelog = "2.5.0"
 intelliJPlatform = "2.14.0"
 qodana = "2025.3.2"
 kover = "0.9.8"
-lsp4ij = "0.19.2"
+lsp4ij = "0.19.3"
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }


### PR DESCRIPTION
Update `lsp4ij` to v0.19.3

See https://github.com/redhat-developer/lsp4ij/releases/tag/0.19.3